### PR TITLE
Compile and use jpsreport on windows

### DIFF
--- a/Analysis.cpp
+++ b/Analysis.cpp
@@ -76,6 +76,7 @@ Analysis::Analysis()
      _DoesUseMethodB = false;                   // Method B (Zhang2011a)
      _DoesUseMethodC = false;                                   // Method C //calculate and save results of classic in separate file
      _DoesUseMethodD = false;                                   // Method D--Voronoi method
+     _DoesUseMethodI = false;
      _cutByCircle = false;  //Adjust whether cut each original voronoi cell by a circle
      _getProfile = false;   // Whether make field analysis or not
      _outputGraph = false;   // Whether output the data for plot the fundamental diagram each frame

--- a/Analysis.cpp
+++ b/Analysis.cpp
@@ -546,17 +546,19 @@ int Analysis::mkpath(char* file_path)
 {
      assert(file_path && *file_path);
      char* p;
-     for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
+	 for (p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
+		 *p = '\\';
+	 }
+     for (p=strchr(file_path+1, '\\'); p; p=strchr(p+1, '\\')) {
           *p='\0';
-
           if (_mkdir(file_path)==-1) {
 
                if (errno!=EEXIST) {
-                    *p='/';
+                    *p='\\';
                     return -1;
                }
           }
-          *p='/';
+          *p='\\';
      }
      return 0;
 }

--- a/Analysis.cpp
+++ b/Analysis.cpp
@@ -332,7 +332,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
                exit(EXIT_FAILURE);
           }
 #pragma omp parallel for
-          for(long int i=0; i < _areaForMethod_A.size(); i++)
+          for(int i=0; i < int(_areaForMethod_A.size()); i++)
           {
                Method_A method_A ;
                method_A.SetMeasurementArea(_areaForMethod_A[i]);
@@ -360,7 +360,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long int i=0; i < _areaForMethod_B.size(); i++)
+          for(int i=0; i < int(_areaForMethod_B.size()); i++)
           {
                Method_B method_B;
                method_B.SetMeasurementArea(_areaForMethod_B[i]);
@@ -385,7 +385,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
                exit(EXIT_FAILURE);
           }
 #pragma omp parallel for
-          for(long int i=0; i < _areaForMethod_C.size(); i++)
+          for(int i=0; i < int(_areaForMethod_C.size()); i++)
           {
                Method_C method_C;
                method_C.SetMeasurementArea(_areaForMethod_C[i]);
@@ -420,7 +420,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long int i=0; i<_areaForMethod_D.size(); i++)
+          for(int i=0; i<int(_areaForMethod_D.size()); i++)
           {
                Method_D method_D;
                method_D.SetStartFrame(_StartFramesMethodD[i]);
@@ -473,7 +473,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long int i=0; i<_areaForMethod_I.size(); i++)
+          for(int i=0; i<int(_areaForMethod_I.size()); i++)
           {
                Method_I method_I;
                method_I.SetStartFrame(_StartFramesMethodI[i]);
@@ -546,9 +546,9 @@ int Analysis::mkpath(char* file_path)
 {
      assert(file_path && *file_path);
      char* p;
-	 for (p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
-		 *p = '\\';
-	 }
+     for (p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
+          *p = '\\';
+	}
      for (p=strchr(file_path+1, '\\'); p; p=strchr(p+1, '\\')) {
           *p='\0';
           if (_mkdir(file_path)==-1) {

--- a/Analysis.cpp
+++ b/Analysis.cpp
@@ -120,7 +120,7 @@ void Analysis::InitArgs(ArgumentParser* args)
 {
      string s = "Parameter:\n";
      _building = new Building();
-     _building->LoadGeometry(args->GetGeometryFilename());
+     _building->LoadGeometry(args->GetGeometryFilename().string());
      // create the polygons
      _building->InitGeometry();
      // _building->AddSurroundingRoom();
@@ -332,7 +332,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
                exit(EXIT_FAILURE);
           }
 #pragma omp parallel for
-          for(long unsigned int i=0; i < _areaForMethod_A.size(); i++)
+          for(long int i=0; i < _areaForMethod_A.size(); i++)
           {
                Method_A method_A ;
                method_A.SetMeasurementArea(_areaForMethod_A[i]);
@@ -360,7 +360,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long unsigned int i=0; i < _areaForMethod_B.size(); i++)
+          for(long int i=0; i < _areaForMethod_B.size(); i++)
           {
                Method_B method_B;
                method_B.SetMeasurementArea(_areaForMethod_B[i]);
@@ -385,7 +385,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
                exit(EXIT_FAILURE);
           }
 #pragma omp parallel for
-          for(long unsigned int i=0; i < _areaForMethod_C.size(); i++)
+          for(long int i=0; i < _areaForMethod_C.size(); i++)
           {
                Method_C method_C;
                method_C.SetMeasurementArea(_areaForMethod_C[i]);
@@ -420,7 +420,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long unsigned int i=0; i<_areaForMethod_D.size(); i++)
+          for(long int i=0; i<_areaForMethod_D.size(); i++)
           {
                Method_D method_D;
                method_D.SetStartFrame(_StartFramesMethodD[i]);
@@ -473,7 +473,7 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
           }
 
 #pragma omp parallel for
-          for(long unsigned int i=0; i<_areaForMethod_I.size(); i++)
+          for(long int i=0; i<_areaForMethod_I.size(); i++)
           {
                Method_I method_I;
                method_I.SetStartFrame(_StartFramesMethodI[i]);

--- a/Analysis.cpp
+++ b/Analysis.cpp
@@ -524,66 +524,19 @@ int Analysis::RunAnalysis(const fs::path& filename, const fs::path& path)
 
 FILE* Analysis::CreateFile(const string& filename)
 {
-     //first try to create the file
+     // create the directory for the file
+     fs::path filepath = fs:: path(filename.c_str()).parent_path();
+     if (fs::is_directory(filepath) == false)
+     {
+         if (fs::create_directories(filepath) == false && fs::is_directory(filepath) == false)
+         {
+             Log->Write("ERROR:\tcannot create the directory <%s>", filepath.string().c_str());
+             return NULL;
+         }
+         Log->Write("INFO:\tcreate the directory <%s>", filepath.string().c_str());
+     }
+     
+     //create the file
      FILE* fHandle= fopen(filename.c_str(),"w");
-     if(fHandle) return fHandle;
-
-     unsigned int found=filename.find_last_of("/\\");
-     string dir = filename.substr(0,found)+"/";
-     //string file= filename.substr(found+1);
-
-     // the directories are probably missing, create it
-     if (mkpath((char*)dir.c_str())==-1) {
-          Log->Write("ERROR:\tcannot create the directory <%s>",dir.c_str());
-          return NULL;
-     }
-     //second and last attempt
-     return fopen(filename.c_str(),"w");
+     return fHandle;
 }
-
-#if defined(_WIN32)
-// @todo: rewrite using boost
-int Analysis::mkpath(char* file_path)
-{
-     assert(file_path && *file_path);
-     char* p;
-     for (p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
-          *p = '\\';
-	}
-     for (p=strchr(file_path+1, '\\'); p; p=strchr(p+1, '\\')) {
-          *p='\0';
-          if (_mkdir(file_path)==-1) {
-
-               if (errno!=EEXIST) {
-                    *p='\\';
-                    return -1;
-               }
-          }
-          *p='\\';
-     }
-     return 0;
-}
-
-#else
-
-// @todo: rewrite using boost
-int Analysis::mkpath(char* file_path, mode_t mode)
-{
-     assert(file_path && *file_path);
-     char* p;
-     for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
-          *p='\0';
-
-          if (mkdir(file_path, mode)==-1) {
-
-               if (errno!=EEXIST) {
-                    *p='/';
-                    return -1;
-               }
-          }
-          *p='/';
-     }
-     return 0;
-}
-// delete
-#endif

--- a/Analysis.h
+++ b/Analysis.h
@@ -65,7 +65,6 @@ public:
      virtual ~Analysis();
 
      void InitArgs(ArgumentParser *args);
-     void InitializeFiles(const std::string& file);
 
      std::map<int, polygon_2d> ReadGeometry(const fs::path& geometryFile, const std::vector<MeasurementArea_B*>& areas);
 
@@ -97,15 +96,6 @@ public:
       * @return
       */
      static FILE* CreateFile(const std::string& filename);
-
-     //TODO: merge apple and linux
-#ifdef __linux__
-     static int mkpath(char* file_path, mode_t mode=0755);
-#elif __APPLE__
-     static int mkpath(char* file_path, mode_t mode=0755);
-#else //windows
-     static int mkpath(char* file_path);
-#endif
 
 private:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,11 +312,14 @@ endif()
 #message (STATUS "PSAPI: ${PSAPI}")
 #endif()
 
-add_library ( geometrycore SHARED ${source_files}  ${methods})
+add_library ( geometrycore STATIC ${source_files}  ${methods})
 set_property(TARGET geometrycore PROPERTY CXX_STANDARD 17)
 set_property(TARGET geometrycore PROPERTY CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-target_link_libraries(geometrycore  stdc++fs)
+
+if(!MSVC)
+	target_link_libraries(geometrycore  stdc++fs)
+endif()
 
 add_executable(
         jpsreport main.cpp
@@ -325,7 +328,9 @@ add_executable(
 set_property(TARGET jpsreport PROPERTY CXX_STANDARD 17)
 set_property(TARGET jpsreport PROPERTY CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-target_link_libraries(jpsreport  stdc++fs)
+if(!MSVC)
+	target_link_libraries(jpsreport  stdc++fs)
+endif()
 
 if (Boost_FOUND)
 target_link_libraries(geometrycore ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ set_property(TARGET geometrycore PROPERTY CXX_STANDARD 17)
 set_property(TARGET geometrycore PROPERTY CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(!MSVC)
+if(NOT MSVC)
 	target_link_libraries(geometrycore  stdc++fs)
 endif()
 
@@ -328,7 +328,7 @@ add_executable(
 set_property(TARGET jpsreport PROPERTY CXX_STANDARD 17)
 set_property(TARGET jpsreport PROPERTY CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-if(!MSVC)
+if(NOT MSVC)
 	target_link_libraries(jpsreport  stdc++fs)
 endif()
 

--- a/general/ArgumentParser.cpp
+++ b/general/ArgumentParser.cpp
@@ -352,6 +352,9 @@ bool ArgumentParser::ParseIniFile(const string& inifile)
                     for (auto& filename : boost::make_iterator_range(fs::directory_iterator(path_traj), {}))
                     {
                          string s = filename.path().string();
+						 string::size_type pos = s.find_last_of('/');
+						 pos = pos == -1 ? s.find_last_of('\\') : pos;
+						 s = pos == -1 ? s : s.substr(pos + 1);
                          if (boost::algorithm::ends_with(s, fmt))
                          {
                               _trajectoriesFiles.push_back(s);
@@ -386,12 +389,14 @@ bool ArgumentParser::ParseIniFile(const string& inifile)
      //scripts
      if(xMainNode->FirstChild("scripts"))
      {
-          _scriptsLocation=fs::path(xMainNode->FirstChildElement("scripts")->Attribute("location"));
+          _scriptsLocation= fs::path(xMainNode->FirstChildElement("scripts")->Attribute("location"));
+		/*
         if(!fs::exists(_scriptsLocation))
         {
              Log->Write("ERROR: \tcould not find the directory <%s>", _scriptsLocation.string().c_str());
              return false;
         }
+		*/
         if(! _scriptsLocation.is_absolute())
         {
              _scriptsLocation = GetProjectRootDir() / _scriptsLocation;

--- a/general/ArgumentParser.cpp
+++ b/general/ArgumentParser.cpp
@@ -352,9 +352,9 @@ bool ArgumentParser::ParseIniFile(const string& inifile)
                     for (auto& filename : boost::make_iterator_range(fs::directory_iterator(path_traj), {}))
                     {
                          string s = filename.path().string();
-						 string::size_type pos = s.find_last_of('/');
-						 pos = pos == -1 ? s.find_last_of('\\') : pos;
-						 s = pos == -1 ? s : s.substr(pos + 1);
+                         int pos = s.find_last_of('/');
+                         pos = pos == -1 ? int(s.find_last_of('\\')) : pos;
+                         s = pos == -1 ? s : s.substr(pos + 1);
                          if (boost::algorithm::ends_with(s, fmt))
                          {
                               _trajectoriesFiles.push_back(s);


### PR DESCRIPTION
- ba4e776 Fix some problems when compiling jpsreport on windows with VS2017. Problem related with OpenMP and link with stdc++fs( it seems that we dont't have to link stdc++fs when compile with MSVC).

- 937c3c6 Since the difference between '/' and '\\', there are some errors when using jpsreport on windows. I have fixed these errors, now it works good on my computer, but the code need to be tested on another windows and on other OS.
